### PR TITLE
#20 feat: added dependencies to generate javadocs pages

### DIFF
--- a/CI-server/pom.xml
+++ b/CI-server/pom.xml
@@ -54,6 +54,16 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.3</version>
+				<configuration>
+					<sourcepath>src/main/java</sourcepath>
+					<subpackages>CIserver</subpackages>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ build:
 
 run:
 	cd CI-server && mvn spring-boot:run
+
+docs:
+	cd CI-server && mvn javadoc:javadoc


### PR DESCRIPTION
- running `make docs` will generate javadocs pages under CI-server/target/site/apidocs